### PR TITLE
Änderung weil nicht funktionsfähig

### DIFF
--- a/querys/btw17.config
+++ b/querys/btw17.config
@@ -20,4 +20,6 @@ KandidatListe=SELECT ID, Vorname, Name FROM Direktkandidaten;
 BestimmterKandidatUndPartei=SELECT Vorname, Name FROM Direktkandidaten D INNER JOIN Partei P on D.P_ID = P.P_ID WHERE Name=@pk OR P_ID=@pk;
 KandidatUndParteiOrderByKandidatAscListe=SELECT Vorname, Name, P_Bezeichnung FROM Direktkandidaten D, Partei P WHERE D.P_ID = P.P_ID ORDER BY Name;
 ParteiUndKandidatOrderByParteiAscListe=SELECT P_Bezeichnung, Vorname, Name FROM Direktkandidaten D, Partei P WHERE D.P_ID = P.P_ID ORDER BY P_Bezeichnung;
-NeuruppinAlsBundestagListe=SELECT P_Bezeichung, (SUM(2Anzahl)/(SELECT SUM(2Anzahl) FROM 2stimme) *299 AS Plätze FROM 2stimme, Partei ORDER BY Plätze DESC;
+PlätzeBestimmterParteiFürNeuruppinAlsBundestag=SELECT P_Bezeichnung, (SUM(2Anzahl)/(SELECT SUM(2Anzahl)/(SELECT SUM(2Anzahl) FROM 2stimme)*100 FROM 2stimme, Partei WHERE 2stimme.P_ID = Partei.P_ID AND Partei.P_ID=@x GROUP BY 2stimme.P_ID)) *2,99 AS Plätze FROM 2stimme, Partei WHERE Partei.P_ID=@x ORDER BY Plätze DESC;
+
+


### PR DESCRIPTION
Neuruppin als Bundestag funktioniert jetzt, allerdings nur für eine Partei auf einmal, weil es anders (nach unserem aktuellen Wissensstand) nicht möglich ist